### PR TITLE
Added minisat like API

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -510,3 +510,18 @@ int kissat_value (kissat *solver, int elit) {
     tmp = -tmp;
   return tmp < 0 ? -elit : elit;
 }
+
+unsigned kissat_nvars (kissat *solver) {
+  return solver->vars;
+}
+
+unsigned kissat_new_var (kissat *solver) {
+  kissat_require_initialized (solver);
+  kissat_require (!GET (searches), "incremental solving not supported");
+  kissat_enlarge_variables(solver, solver->vars + 1);
+  return solver->vars - 1;
+}
+
+bool kissat_okay (kissat *solver) {
+  return !solver->inconsistent;
+}

--- a/src/kissat.h
+++ b/src/kissat.h
@@ -39,4 +39,10 @@ void kissat_set_decision_limit (kissat *solver, unsigned);
 
 void kissat_print_statistics (kissat *solver);
 
+// Minisat like API
+#include <stdbool.h>
+unsigned kissat_nvars (kissat *solver);
+unsigned kissat_new_var (kissat *solver);
+bool kissat_okay (kissat *solver);
+
 #endif


### PR DESCRIPTION
Dear Prof. Armin Biere,

 Hello, I'm Kotaro Matsuoka, a Ph.D. student at Kyoto University, Japan.

 I’m submitting this PR to propose the addition of APIs to Kissat, which do not affect the SAT-solving behavior itself, but aim to make it more accessible for use in SMT solvers, particularly in  [STP](https://github.com/stp/stp.git). 

 Recently, I've been working on my research work which uses [Bitwuzla](https://github.com/bitwuzla/bitwuzla) and [STP](https://github.com/stp/stp.git) as SMT solvers for BF_QV problems. These two solvers are [top 2 solvers in this year's competition](https://smt-comp.github.io/2024/results/qf_bitvec-single-query/). 

 I noticed that Bitwuzla already supports a somewhat older version of Kissat, and I recently modified it to support the latest version. The changes have been  [merged](https://github.com/bitwuzla/bitwuzla/pull/124). 

 However, STP does not currently support Kissat, possibly due to missing functionalities in its API when compared to other supported solvers like Minisat, Riss, and CryptoMiniSat. This is why I wrote this PR. I already wrote the PR for integrating the code I'm proposing to STP, so if you want to see how these changes will work in a real application, see [this PR](https://github.com/stp/stp/pull/497). 

 Because the main motivation for me to make this PR is just a workable implementation, I possibly made a mistake on this PR. One of the most suspicious candidates is `kissat_okay`. I'm not sure this is the correct implementation for the intended functionality. If you think this seems to be wrong, I’d greatly appreciate your feedback.
 
 Last but not least, I hope to say thank you for your great work!
 
 Sincerely, 
 Kotaro Matsuoka