### PR TITLE
Fix bitwise NOTs that should be logical NOTs

### DIFF
--- a/test/testfile.c
+++ b/test/testfile.c
@@ -40,7 +40,7 @@ static void test_file_readable (void) {
     bool RES = kissat_file_readable (PATH); \
     if (RES && EXPECTED) \
       printf ("file '%s' determined to be readable as expected\n", PATH); \
-    else if (!RES && ~EXPECTED) \
+    else if (!RES && !EXPECTED) \
       printf ("file '%s' determined not to be readable as expected\n", \
               PATH); \
     else if (RES && !EXPECTED) \
@@ -66,7 +66,7 @@ static void test_file_writable (void) {
     bool RES = kissat_file_writable (PATH); \
     if (RES && EXPECTED) \
       printf ("file '%s' determined to be writable as expected\n", PATH); \
-    else if (!RES && ~EXPECTED) \
+    else if (!RES && !EXPECTED) \
       printf ("file '%s' determined not to be writable as expected\n", \
               PATH); \
     else if (RES && !EXPECTED) \


### PR DESCRIPTION
I saw many warnings of this form while building the tests for version 4.0.4:
```
../test/testfile.c: In function ‘test_file_readable’:
../test/testfile.c:43:22: warning: ‘~’ on a boolean expression [-Wbool-operation]
   43 |     else if (!RES && ~EXPECTED) \
      |                      ^
../test/testfile.c:53:3: note: in expansion of macro ‘READABLE’
   53 |   READABLE (false, "non-existing-file");
      |   ^~~~~~~~
../test/testfile.c:43:22: note: did you mean to use logical not?
   43 |     else if (!RES && ~EXPECTED) \
      |                      ^
../test/testfile.c:53:3: note: in expansion of macro ‘READABLE’
   53 |   READABLE (false, "non-existing-file");
      |   ^~~~~~~~
```

This PR changes the erroneous bitwise NOT operations to logical NOT operations.  Note that in both cases, the correct NOT operator is already used 3 lines below the changed line.